### PR TITLE
fix: allow pixsnap domain for api requests

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,0 +1,12 @@
+# Configuration Guide
+
+The Workflow SG server reads the following environment variables at runtime:
+
+| Variable | Required | Description |
+| --- | --- | --- |
+| `OPENAI_API_KEY` | No | Enables the `/api/chat` endpoint. When unset, the endpoint responds with a `503` indicating the chat service is unavailable. |
+| `USE_OPENAI_FILE_TOOL` | No | When set to `true`, the agent attempts to initialise the OpenAI file search tool. Falls back to local file search if initialisation fails. |
+| `MODEL` | No | Overrides the default model (`gpt-5`) used by the assistant agent. |
+| `ALLOWED_ORIGINS` | No | Comma-separated list of additional origins that are permitted to access the API. These entries are merged with built-in Workflow SG domains (including `https://pixsnap.workflow.sg`) and common localhost ports. |
+
+Origins listed in `ALLOWED_ORIGINS` are compared case-insensitively. All subdomains under `*.workflow.sg` are accepted by default.


### PR DESCRIPTION
## Summary
- add an allow list driven CORS configuration that includes pixsnap.workflow.sg and common localhost origins
- return a clear 403 JSON error when a request is rejected for an unapproved origin
- document the ALLOWED_ORIGINS override in docs/configuration.md

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dd06467a788328856b4d087a518b0b